### PR TITLE
Remove builtin modules from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,6 @@
-re
-base64
 requests
 argparse
 rich
 urllib3
 alive-progress
 prompt_toolkit
-concurrent-futures


### PR DESCRIPTION
Remove builtin module from requirements.txt, trying to pip builtin module would cause the error.